### PR TITLE
fix: :bug: Use `channelGenerator` to set `sec-websocket-protocol` header.

### DIFF
--- a/lib/services/dpm/graphql_dpm_service.dart
+++ b/lib/services/dpm/graphql_dpm_service.dart
@@ -7,6 +7,7 @@ import 'package:built_collection/built_collection.dart';
 import "package:gql_websocket_link/gql_websocket_link.dart";
 import 'package:gql_http_link/gql_http_link.dart';
 import 'package:ferry/ferry.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:parameter_page/gql-dpm/schema/__generated__/DPM.schema.gql.dart';
 import 'package:parameter_page/gql-dpm/schema/__generated__/get_device_info.req.gql.dart';
 import 'package:parameter_page/gql-dpm/schema/__generated__/get_device_info.data.gql.dart';
@@ -40,17 +41,17 @@ class GraphQLDpmService extends DpmService {
           cache: Cache(),
         ),
         _s = Client(
-          link: WebSocketLink(
-              Uri(
-                scheme: "wss",
-                host: "acsys-proxy.fnal.gov",
-                port: 8000,
-                path: "/acsys",
-              ).toString(),
-              reconnectInterval: const Duration(seconds: 1),
-              initialPayload: {
-                "headers": {"sec-websocket-protocol": "graphql-ws"}
-              }),
+          link: WebSocketLink(null,
+              channelGenerator: () => WebSocketChannel.connect(
+                    Uri(
+                      scheme: "wss",
+                      host: "acsys-proxy.fnal.gov",
+                      port: 8000,
+                      path: "/acsys",
+                    ),
+                    protocols: ["graphql-ws"],
+                  ),
+              reconnectInterval: const Duration(seconds: 1)),
           cache: Cache(),
         );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -949,7 +949,7 @@ packages:
     source: hosted
     version: "0.1.4-beta"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
     logger: ^1.1.0
     flutter_dotenv: ^5.1.0
     go_router: ^10.1.2
+    web_socket_channel: ^2.4.0
 
 dev_dependencies:
     integration_test:


### PR DESCRIPTION
Chrome wasn't accepting our secure websocket requests because of how the handshake was happening. This uses a different strategy to set the appropriate protocol header.