### PR TITLE
Use v0.1.x branch of `flutter_controls_core`

### DIFF
--- a/lib/widgets/entryquerywrapper_widget.dart
+++ b/lib/widgets/entryquerywrapper_widget.dart
@@ -9,10 +9,10 @@ class EntryQueryWrapper extends StatefulWidget {
   final Function fetchData;
 
   const EntryQueryWrapper({
-    Key? key,
+    super.key,
     required this.entries,
     required this.fetchData,
-  }) : super(key: key);
+  });
 
   @override
   State<EntryQueryWrapper> createState() => _EntryQueryWrapperState();

--- a/lib/widgets/open_pages_list_view_widget.dart
+++ b/lib/widgets/open_pages_list_view_widget.dart
@@ -9,12 +9,11 @@ class OpenPagesListViewWidget extends StatefulWidget {
   final Function(String pageId, String pageTitle) onSelected;
 
   const OpenPagesListViewWidget(
-      {Key? key,
+      {super.key,
       required this.titles,
       required this.fetchData,
       required this.service,
-      required this.onSelected})
-      : super(key: key);
+      required this.onSelected});
 
   @override
   State<OpenPagesListViewWidget> createState() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,7 +57,7 @@ dev_dependencies:
     # activated in the `analysis_options.yaml` file located at the root of your
     # package. See that file for information about deactivating specific lint
     # rules and activating additional ones.
-    flutter_lints: ^2.0.0
+    flutter_lints: ^3.0.0
     test: ^1.22.0
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
     flutter_controls_core:
         git:
             url: https://github.com/fermi-ad/flutter-controls-core.git
-            ref: main
+            ref: v0.1.x
 
 dev_dependencies:
     integration_test:


### PR DESCRIPTION
The main purpose of this pull request is to make the parameter page switch to the v0.1.x branch of `flutter_controls_core`. The `-core` library is in its infancy and will go through massive growth, including refactorization. We'll keep the patch-level branches backward compatible so the parameter page won't have to modified to keep up with every change; they can be done when the parameter page needs a feature in a newer branch.

This pull request also includes a bump in the linter version, and includes resolving two warnings the linter generated.