### PR TITLE
Fix CD workflow: add step to generate the .env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checking out source code
         uses: actions/checkout@v3
 
+      - name: Generate test configuration
+        run: |
+          cp .env-test .env
+
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"


### PR DESCRIPTION
Build is failing with the error: No file or variants found for asset: .env.